### PR TITLE
Paper over traceback thrown when on detached git HEAD

### DIFF
--- a/src/core/util/json_utils.py
+++ b/src/core/util/json_utils.py
@@ -110,7 +110,13 @@ def create_run_log(app):
     repo = git.Repo(PathManager.get_module_dir())
     meta['iris_version'] = 2.0
     meta['iris_repo'] = repo.working_tree_dir
-    meta['iris_branch'] = repo.active_branch.name
+    try:
+        meta['iris_branch'] = repo.active_branch.name
+    except:
+        # If we're on a detached head, the active_branch is
+        # undefined and raises an exception. This at least
+        # allows the test run to finish
+        meta['iris_branch'] = "detached"
     meta['iris_branch_head'] = repo.head.object.hexsha
     meta['python_version'] = get_python_version()
 


### PR DESCRIPTION
Run reports include the git branch name used when the run occured. If you're on a detached head, it throws a traceback and fails the run.

This papers over the error by catching that exception and just calling the branch 'detached' and moving on.