### PR TITLE
Added blocked by issue_3222 to tab_history_is_saved_after_restoring_firefox_from_crash test case

### DIFF
--- a/tests/firefox/session_restore/tab_history_is_saved_after_restoring_firefox_from_crash.py
+++ b/tests/firefox/session_restore/tab_history_is_saved_after_restoring_firefox_from_crash.py
@@ -13,6 +13,7 @@ class Test(FirefoxTest):
         test_case_id='114828',
         test_suite_id='68',
         locales=Locales.ENGLISH,
+        blocked_by={'id': 'issue_3222', 'platform': OSPlatform.ALL}
     )
     def run(self, firefox):
         restore_previous_session_checkbox_pattern = Pattern('restore_previous_session_checkbox.png')


### PR DESCRIPTION
Added coverage for #3536 , please review