### PR TITLE
Fix no_crash_closing_pinned test case

### DIFF
--- a/tests/firefox/antivirus/no_crash_closing_pinned.py
+++ b/tests/firefox/antivirus/no_crash_closing_pinned.py
@@ -21,7 +21,7 @@ class Test(FirefoxTest):
         mozilla_pinned_tab_pattern = Pattern('mozilla_pinned_tab.png')
         firefox_tab_pattern = Pattern('firefox_tab.png')
         firefox_pinned_tab_pattern = Pattern('firefox_pinned_tab.png')
-        focus_tab_pattern = Pattern('focus_tab.png')
+        focus_tab_pattern = Pattern('focus_tab.png').similar(0.6)
         focus_pinned_tab_pattern = Pattern('focus_pinned_tab.png')
 
         new_tab()


### PR DESCRIPTION
Fixed #2865 for win7 by lowering similarity, shouldn't affect other OS ver.