### PR TITLE
Fix bookmarks_toolbar_navigate_through_history test

### DIFF
--- a/tests/firefox/history/bookmarks_toolbar_navigate_through_history.py
+++ b/tests/firefox/history/bookmarks_toolbar_navigate_through_history.py
@@ -56,7 +56,7 @@ class Test(FirefoxTest):
 
         new_tab()
 
-        expected = exists(history_bookmarks_toolbar_pattern)
+        expected = exists(history_bookmarks_toolbar_pattern, FirefoxSettings.FIREFOX_TIMEOUT)
         assert expected, 'History section is displayed in the Bookmarks Toolbar.'
 
         click(history_bookmarks_toolbar_pattern)


### PR DESCRIPTION
Added timeout to prevent fails on win, win7. Review, please #3213