### PR TITLE
Increase timeouts to improve stablity on slower machines

### DIFF
--- a/targets/nightly/firefox_ui/helpers/keyboard_shortcuts.py
+++ b/targets/nightly/firefox_ui/helpers/keyboard_shortcuts.py
@@ -554,6 +554,7 @@ def history_sidebar():
         type(text='h', modifier=[KeyModifier.CMD, KeyModifier.SHIFT])
     else:
         type(text='h', modifier=KeyModifier.CTRL)
+    time.sleep(Settings.DEFAULT_UI_DELAY)
 
 
 def clear_recent_history():
@@ -609,6 +610,7 @@ def bookmarks_sidebar(option: str):
             raise APIHelperError('Sidebar is NOT closed, aborting.')
     else:
         raise APIHelperError('Option is not supported, aborting')
+    time.sleep(Settings.DEFAULT_UI_DELAY)
 
 
 def open_library():
@@ -619,6 +621,7 @@ def open_library():
         type(text='b', modifier=[KeyModifier.CTRL, KeyModifier.SHIFT])
     else:
         type(text='o', modifier=[KeyModifier.CTRL, KeyModifier.SHIFT])
+    time.sleep(Settings.DEFAULT_UI_DELAY)
 
 
 # End History & Bookmarks keyboard shortcuts.

--- a/tests/nightly/awesomebar/one_off_searches_in_private_window.py
+++ b/tests/nightly/awesomebar/one_off_searches_in_private_window.py
@@ -31,7 +31,7 @@ class Test(FirefoxTest):
 
         region = Region(0, 0, Screen().width, 2 * Screen().height / 3)
 
-        test_page_loaded = exists(LocalWeb.FIREFOX_LOGO, FirefoxSettings.FIREFOX_TIMEOUT)
+        test_page_loaded = exists(LocalWeb.FIREFOX_LOGO, FirefoxSettings.SITE_LOAD_TIMEOUT)
         assert test_page_loaded, 'Page successfully loaded, firefox logo found.'
 
         select_location_bar()
@@ -54,8 +54,8 @@ class Test(FirefoxTest):
         type(Key.ENTER)
         time.sleep(Settings.DEFAULT_UI_DELAY_LONG)
 
-        twitter_result_displayed = exists(new_tab_twitter_search_results_pattern, FirefoxSettings.FIREFOX_TIMEOUT) or\
-                                   exists(new_tab_twitter_search_results_pattern2, FirefoxSettings.FIREFOX_TIMEOUT)
+        twitter_result_displayed = exists(new_tab_twitter_search_results_pattern, FirefoxSettings.SITE_LOAD_TIMEOUT) or\
+                                   exists(new_tab_twitter_search_results_pattern2, FirefoxSettings.SITE_LOAD_TIMEOUT)
         assert twitter_result_displayed, 'Twitter search results are opened in the same tab.'
 
         new_tab()
@@ -65,7 +65,7 @@ class Test(FirefoxTest):
         paste('test')
 
         google_button_found = region.exists(google_on_off_button_private_window_pattern,
-                                            FirefoxSettings.FIREFOX_TIMEOUT)
+                                            FirefoxSettings.SITE_LOAD_TIMEOUT)
         assert google_button_found, 'The\'Google\' one-off button found.'
 
         if OSHelper.is_mac():
@@ -82,7 +82,7 @@ class Test(FirefoxTest):
 
         next_tab()
 
-        google_page_opened = region.exists(magnifying_glass_pattern, FirefoxSettings.FIREFOX_TIMEOUT)
+        google_page_opened = region.exists(magnifying_glass_pattern, FirefoxSettings.SITE_LOAD_TIMEOUT)
         assert google_page_opened, 'Page successfully loaded using the \'Google\' engine.'
 
         google_result_displayed = region.exists(test_pattern, FirefoxSettings.FIREFOX_TIMEOUT)

--- a/tests/nightly/awesomebar/perform_a_search_using_a_one_off.py
+++ b/tests/nightly/awesomebar/perform_a_search_using_a_one_off.py
@@ -26,7 +26,7 @@ class Test(FirefoxTest):
         region = Screen().new_region(0, 0, Screen.SCREEN_WIDTH, 2 * Screen.SCREEN_HEIGHT / 3)
         navigate(LocalWeb.MOZILLA_TEST_SITE)
 
-        expected = region.exists(LocalWeb.MOZILLA_LOGO, FirefoxSettings.FIREFOX_TIMEOUT)
+        expected = region.exists(LocalWeb.MOZILLA_LOGO, FirefoxSettings.SITE_LOAD_TIMEOUT)
         assert expected, 'Mozilla page loaded successfully.'
 
         bookmark_page()
@@ -37,13 +37,13 @@ class Test(FirefoxTest):
         new_tab()
         navigate(LocalWeb.FIREFOX_TEST_SITE)
 
-        expected = region.exists(LocalWeb.FIREFOX_LOGO, FirefoxSettings.FIREFOX_TIMEOUT)
+        expected = region.exists(LocalWeb.FIREFOX_LOGO, FirefoxSettings.SITE_LOAD_TIMEOUT)
         assert expected, 'Firefox page loaded successfully.'
 
         new_tab()
         navigate(LocalWeb.FOCUS_TEST_SITE)
 
-        expected = region.exists(LocalWeb.FOCUS_LOGO, FirefoxSettings.FIREFOX_TIMEOUT)
+        expected = region.exists(LocalWeb.FOCUS_LOGO, FirefoxSettings.SITE_LOAD_TIMEOUT)
         assert expected, 'Focus page loaded successfully.'
 
         firefox.restart(LocalWeb.FIREFOX_TEST_SITE, image=LocalWeb.FIREFOX_LOGO)
@@ -53,19 +53,19 @@ class Test(FirefoxTest):
         select_location_bar()
         paste('m')
 
-        expected = region.exists(search_suggestion_bookmarked_tab_pattern, FirefoxSettings.FIREFOX_TIMEOUT)
+        expected = region.exists(search_suggestion_bookmarked_tab_pattern, FirefoxSettings.SITE_LOAD_TIMEOUT)
         assert expected, 'Bookmarked page found between search suggestions.'
 
         select_location_bar()
         paste('o')
 
-        expected = region.exists(search_suggestion_opened_tab_pattern, FirefoxSettings.FIREFOX_TIMEOUT)
+        expected = region.exists(search_suggestion_opened_tab_pattern, FirefoxSettings.SITE_LOAD_TIMEOUT)
         assert expected, 'Opened tab found between search suggestions.'
 
         select_location_bar()
         paste('f')
 
-        expected = region.exists(search_suggestion_history_pattern, FirefoxSettings.FIREFOX_TIMEOUT)
+        expected = region.exists(search_suggestion_history_pattern, FirefoxSettings.SITE_LOAD_TIMEOUT)
         assert expected, 'Web pages from personal browsing history found between search suggestions.'
 
         expected = region.exists(popular_search_suggestion_pattern, FirefoxSettings.FIREFOX_TIMEOUT)
@@ -77,6 +77,6 @@ class Test(FirefoxTest):
         click(google_one_off_button_pattern)
         time.sleep(FirefoxSettings.TINY_FIREFOX_TIMEOUT)
 
-        expected = exists(google_search_results_pattern.similar(0.7), FirefoxSettings.FIREFOX_TIMEOUT,
+        expected = exists(google_search_results_pattern.similar(0.7), FirefoxSettings.SITE_LOAD_TIMEOUT,
                           region=Screen.TOP_THIRD)
         assert expected, 'Google search results are displayed.'

--- a/tests/nightly/bookmark/bookmark_via_star_button.py
+++ b/tests/nightly/bookmark/bookmark_via_star_button.py
@@ -19,7 +19,7 @@ class Test(FirefoxTest):
 
         navigate(LocalWeb.MOZILLA_TEST_SITE)
 
-        mozilla_page_assert = exists(LocalWeb.MOZILLA_LOGO, FirefoxSettings.FIREFOX_TIMEOUT)
+        mozilla_page_assert = exists(LocalWeb.MOZILLA_LOGO, FirefoxSettings.SITE_LOAD_TIMEOUT)
         assert mozilla_page_assert, 'Mozilla page loaded successfully.'
 
         try:
@@ -29,5 +29,6 @@ class Test(FirefoxTest):
         except FindError:
             raise FindError('Bookmark star is not present on the page, aborting.')
 
-        page_bookmarked_assert = exists(Bookmarks.StarDialog.NEW_BOOKMARK, FirefoxSettings.FIREFOX_TIMEOUT)
+        page_bookmarked_assert = exists(Bookmarks.StarDialog.NEW_BOOKMARK.similar(0.7), FirefoxSettings.FIREFOX_TIMEOUT,
+                                        region=Screen.TOP_THIRD)
         assert page_bookmarked_assert, 'The page was successfully bookmarked via star button.'

--- a/tests/nightly/history/clear_all_history.py
+++ b/tests/nightly/history/clear_all_history.py
@@ -25,12 +25,12 @@ class Test(FirefoxTest):
 
         reset_mouse()
 
-        expected_1 = exists(LocalWeb.MOZILLA_LOGO, 10)
+        expected_1 = exists(LocalWeb.MOZILLA_LOGO, FirefoxSettings.SITE_LOAD_TIMEOUT)
         assert expected_1, 'Mozilla page loaded successfully.'
 
         new_tab()
         navigate(LocalWeb.FIREFOX_TEST_SITE)
-        expected_2 = exists(LocalWeb.FIREFOX_LOGO, 10)
+        expected_2 = exists(LocalWeb.FIREFOX_LOGO, FirefoxSettings.SITE_LOAD_TIMEOUT)
         assert expected_2, 'Firefox page loaded successfully.'
 
         # Open the History sidebar.

--- a/tests/nightly/search_and_update/default_search_code_yandex.py
+++ b/tests/nightly/search_and_update/default_search_code_yandex.py
@@ -98,7 +98,7 @@ class Test(FirefoxTest):
         assert expected, 'Yandex logo from content search field found.'
 
         click(yandex_logo_content_search_field_pattern)
-        time.sleep(Settings.DEFAULT_UI_DELAY+LONG)
+        time.sleep(Settings.DEFAULT_UI_DELAY_LONG)
 
         type('beats', interval=0.25)
         time.sleep(FirefoxSettings.TINY_FIREFOX_TIMEOUT)

--- a/tests/nightly/search_and_update/default_search_code_yandex.py
+++ b/tests/nightly/search_and_update/default_search_code_yandex.py
@@ -43,7 +43,7 @@ class Test(FirefoxTest):
 
         navigate('about:preferences#search')
 
-        expected = exists(default_search_engine_yandex_pattern, FirefoxSettings.FIREFOX_TIMEOUT)
+        expected = exists(default_search_engine_yandex_pattern, FirefoxSettings.SITE_LOAD_TIMEOUT)
         assert expected, 'Yandex is the default search engine.'
 
         # Perform a search using the awesome bar and then clear the content from it.
@@ -76,7 +76,7 @@ class Test(FirefoxTest):
         # Highlight some text and right click it.
         new_tab()
         navigate(url)
-        expected = exists(LocalWeb.FOCUS_LOGO, 10)
+        expected = exists(LocalWeb.FOCUS_LOGO, FirefoxSettings.SITE_LOAD_TIMEOUT)
         assert expected, 'Page successfully loaded, Focus logo found.'
 
         double_click(text_pattern)
@@ -94,11 +94,11 @@ class Test(FirefoxTest):
 
         # Perform a search from about:newtab page, content search field.
         new_tab()
-        expected = exists(yandex_logo_content_search_field_pattern, FirefoxSettings.FIREFOX_TIMEOUT)
+        expected = exists(yandex_logo_content_search_field_pattern, FirefoxSettings.SITE_LOAD_TIMEOUT)
         assert expected, 'Yandex logo from content search field found.'
 
         click(yandex_logo_content_search_field_pattern)
-        time.sleep(Settings.DEFAULT_UI_DELAY)
+        time.sleep(Settings.DEFAULT_UI_DELAY+LONG)
 
         type('beats', interval=0.25)
         time.sleep(FirefoxSettings.TINY_FIREFOX_TIMEOUT)

--- a/tests/nightly/search_and_update/search_code_testing_DuckDuckGo_us.py
+++ b/tests/nightly/search_and_update/search_code_testing_DuckDuckGo_us.py
@@ -24,7 +24,7 @@ class Test(FirefoxTest):
         navigate('about:preferences#search')
 
         default_search_engine_google_exists = exists(default_search_engine_google_pattern.similar(0.7),
-                                                     FirefoxSettings.FIREFOX_TIMEOUT)
+                                                     FirefoxSettings.SITE_LOAD_TIMEOUT)
         assert default_search_engine_google_exists is True, 'Google is the default search engine.'
 
         # Change the default search engine to DuckDuckGo.
@@ -35,12 +35,13 @@ class Test(FirefoxTest):
         click(default_search_engine_dropdown_pattern)
         repeat_key_down(3)
         type(Key.ENTER)
+        time.sleep(Settings.DEFAULT_UI_DELAY)
 
         select_location_bar()
         type('test', interval=0.25)
         type(Key.ENTER)
 
-        test_search_duckduckgo_exists = exists(test_search_duckduckgo_pattern, FirefoxSettings.FIREFOX_TIMEOUT)
+        test_search_duckduckgo_exists = exists(test_search_duckduckgo_pattern, FirefoxSettings.SITE_LOAD_TIMEOUT)
         assert test_search_duckduckgo_exists is True, 'The search is performed with the DuckDuckGo engine.'
 
         time.sleep(FirefoxSettings.TINY_FIREFOX_TIMEOUT)

--- a/tests/nightly/search_and_update/search_code_testing_bing_us.py
+++ b/tests/nightly/search_and_update/search_code_testing_bing_us.py
@@ -24,7 +24,7 @@ class Test(FirefoxTest):
         navigate('about:preferences#search')
 
         default_search_engine_google_exists = exists(default_search_engine_google_pattern.similar(0.7),
-                                                     FirefoxSettings.FIREFOX_TIMEOUT)
+                                                     FirefoxSettings.SITE_LOAD_TIMEOUT)
         assert default_search_engine_google_exists is True, 'Google is the default search engine.'
 
         # Change the default search engine to Bing.
@@ -36,12 +36,13 @@ class Test(FirefoxTest):
         click(default_search_engine_dropdown_pattern)
         repeat_key_down(1)
         type(Key.ENTER)
+        time.sleep(Settings.DEFAULT_UI_DELAY)
 
         select_location_bar()
         type('test', interval=0.25)
         type(Key.ENTER)
 
-        test_search_bing_exists = exists(test_search_bing_pattern, FirefoxSettings.FIREFOX_TIMEOUT)
+        test_search_bing_exists = exists(test_search_bing_pattern, FirefoxSettings.SITE_LOAD_TIMEOUT)
         assert test_search_bing_exists is True, 'The search is performed with the Bing engine.'
 
         select_location_bar()

--- a/tests/nightly/session_restore/previous_session_can_be_restored_from_firefox_menu.py
+++ b/tests/nightly/session_restore/previous_session_can_be_restored_from_firefox_menu.py
@@ -27,13 +27,8 @@ class Test(FirefoxTest):
         test_site_opened = exists(LocalWeb.POCKET_LOGO, FirefoxSettings.SITE_LOAD_TIMEOUT)
         assert test_site_opened, 'Pocket test website is opened'
 
-        if OSHelper.is_mac():
-            quit_firefox()
-        elif OSHelper.is_linux():
-            click_hamburger_menu_option('Quit')
-        else:
-            click_hamburger_menu_option('Exit')
-
+        quit_firefox()
+        time.sleep(Settings.DEFAULT_SYSTEM_DELAY)
         firefox.restart()
 
         firefox_restarted = exists(LocalWeb.IRIS_LOGO, FirefoxSettings.SITE_LOAD_TIMEOUT)


### PR DESCRIPTION
First attempt at solving test failures in treeherder.  Without debug images, I'm flying a bit blind here.  This first try is to adjust certain timeouts to give the browser on slower machines time to load pages and other content.