### PR TITLE
Issue 4304: Fixed

### DIFF
--- a/tests/firefox/prefs/search_bar_can_be_enabled_disabled.py
+++ b/tests/firefox/prefs/search_bar_can_be_enabled_disabled.py
@@ -11,8 +11,7 @@ class Test(FirefoxTest):
         description="Firefox Home Content - Search bar can be enabled/disabled",
         test_case_id="161665",
         test_suite_id="2241",
-        locale=["en-US"],
-        blocked_by={"id": "4304", "platform": OSPlatform.ALL}
+        locale=["en-US"]
     )
     def run(self, firefox):
         web_search_options_pattern = Pattern("web_search_options.png")
@@ -70,17 +69,20 @@ class Test(FirefoxTest):
 
         navigate("about:home")
 
-        google_logo_content_search_field = exists(google_logo_content_search_field_pattern)
+        google_logo_content_search_field = exists(google_logo_content_search_field_pattern,
+                                                  FirefoxSettings.FIREFOX_TIMEOUT)
         assert google_logo_content_search_field is False, "The search bar is not displayed anymore on the Home page."
 
         navigate("about:newtab")
 
-        google_logo_content_search_field = exists(google_logo_content_search_field_pattern)
+        google_logo_content_search_field = exists(google_logo_content_search_field_pattern,
+                                                  FirefoxSettings.FIREFOX_TIMEOUT)
         assert google_logo_content_search_field is False, "The search bar is not displayed anymore on the New Tab page."
 
         new_window()
 
-        google_logo_content_search_field = exists(google_logo_content_search_field_pattern)
+        google_logo_content_search_field = exists(google_logo_content_search_field_pattern,
+                                                  FirefoxSettings.FIREFOX_TIMEOUT)
         assert google_logo_content_search_field is False, "The search bar is not displayed anymore in the New Window."
 
         new_private_window()
@@ -89,6 +91,6 @@ class Test(FirefoxTest):
         assert private_window_opened, "Private window opened"
 
         google_logo_content_search_field = exists(google_logo_content_search_field_pattern)
-        assert google_logo_content_search_field is False, (
+        assert google_logo_content_search_field, (
             "The search bar is not displayed anymore in the New " "Private Window."
         )


### PR DESCRIPTION
As per the latest test case description and [Bugzilla defect](https://bugzilla.mozilla.org/show_bug.cgi?id=1523117):  "private browsing mode isn't meant to be customizable". Hence, google search will always display  (irrespective of the user's setting) in the private browsing launching page. 

Updated teat script, working fine in all OS. Please review and merge. close #4304