### PR TITLE
15 Test scripts blocked from nightly run execution

### DIFF
--- a/tests/firefox/anti_tracking/delete_cookies_when_closing.py
+++ b/tests/firefox/anti_tracking/delete_cookies_when_closing.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="106157",
         test_suite_id="1826",
+        blocked_by={"id": "4477", "platform": [OSPlatform.WINDOWS, OSPlatform.MAC]},
     )
     def run(self, firefox):
         preferences_privacy_page_pattern = AboutPreferences.PRIVACY_AND_SECURITY_BUTTON_SELECTED

--- a/tests/firefox/anti_tracking/no_third_party_cookies.py
+++ b/tests/firefox/anti_tracking/no_third_party_cookies.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="106156",
         test_suite_id="1826",
+        blocked_by={"id": "4478", "platform": [OSPlatform.WINDOWS, OSPlatform.MAC]},
     )
     def run(self, firefox):
         all_third_party_cookies_pattern = Pattern("all_third_party_cookies.png").similar(0.6)

--- a/tests/firefox/anti_tracking/private_browsing_autofill.py
+++ b/tests/firefox/anti_tracking/private_browsing_autofill.py
@@ -13,6 +13,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="101666",
         test_suite_id="1826",
+        blocked_by={"id": "4479", "platform": OSPlatform.WINDOWS},
         preferences={"extensions.formautofill.available": "on"},
     )
     def run(self, firefox):

--- a/tests/firefox/anti_tracking/saved_cc_available_in_private_session.py
+++ b/tests/firefox/anti_tracking/saved_cc_available_in_private_session.py
@@ -13,6 +13,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="101667",
         test_suite_id="1826",
+        blocked_by={"id": "4476", "platform": OSPlatform.ALL},
         preferences={"extensions.formautofill.available": "on", "extensions.formautofill.creditCards.available": True},
     )
     def run(self, firefox):

--- a/tests/firefox/awesomebar/add_links_keyboard_shortcuts.py
+++ b/tests/firefox/awesomebar/add_links_keyboard_shortcuts.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="119484",
         test_suite_id="1902",
+        blocked_by={"id": "4480", "platform": [OSPlatform.WINDOWS, OSPlatform.MAC]}
     )
     def run(self, firefox):
         cnn_tab_pattern = Pattern("cnn_tab.png")

--- a/tests/firefox/download_manager/download_paused_unpaused.py
+++ b/tests/firefox/download_manager/download_paused_unpaused.py
@@ -17,7 +17,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="99471",
         test_suite_id="1827",
-        blocked_by={"id": "4386", "platform": OSPlatform.LINUX},
+        blocked_by={"id": "4386", "platform": OSPlatform.ALL},
         profile=Profiles.BRAND_NEW,
         preferences={
             "browser.download.dir": PathManager.get_downloads_dir(),

--- a/tests/firefox/drag_and_drop/paste_html.py
+++ b/tests/firefox/drag_and_drop/paste_html.py
@@ -8,7 +8,12 @@ from targets.firefox.fx_testcase import *
 
 class Test(FirefoxTest):
     @pytest.mark.details(
-        description="Paste html data in demopage", locale=["en-US"], test_case_id="165100", test_suite_id="5259"
+        description="Paste html data in demopage",
+        locale=["en-US"],
+        test_case_id="165100",
+        test_suite_id="5259",
+        blocked_by={"id": "4481", "platform": OSPlatform.ALL},
+
     )
     def run(self, firefox):
         paste_html_data_radiobutton_selected_pattern = Pattern("paste_html_data_selected.png")

--- a/tests/firefox/drag_and_drop/paste_html_in_private_window.py
+++ b/tests/firefox/drag_and_drop/paste_html_in_private_window.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="165101",
         test_suite_id="5259",
+        blocked_by={"id": "4482", "platform": OSPlatform.ALL},
     )
     def run(self, firefox):
         paste_html_data_radiobutton_pattern = Pattern("paste_html_data.png")

--- a/tests/firefox/find_toolbar/find_with_dark_background.py
+++ b/tests/firefox/find_toolbar/find_with_dark_background.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="127242",
         test_suite_id="2085",
+        blocked_by={"id": "4485", "platform": OSPlatform.ALL},
     )
     def run(self, firefox):
         work_in_label_pattern = Pattern("work_in_selected_label.png")

--- a/tests/firefox/prefs/ff_home_content_highlights_displayed_in_1_or_2_rows.py
+++ b/tests/firefox/prefs/ff_home_content_highlights_displayed_in_1_or_2_rows.py
@@ -12,7 +12,9 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="171440",
         test_suite_id="2241",
-        preferences={'devtools.chrome.enabled': True}
+        preferences={'devtools.chrome.enabled': True},
+        blocked_by={"id": "4483", "platform": OSPlatform.ALL},
+
     )
     def run(self, firefox):
         about_preferences_home_url_pattern = Pattern('about_preferences_home_url.png')

--- a/tests/firefox/prefs/ff_select_which_highlights_to_display.py
+++ b/tests/firefox/prefs/ff_select_which_highlights_to_display.py
@@ -11,6 +11,8 @@ class Test(FirefoxTest):
         test_case_id="161671",
         test_suite_id="2241",
         locale=["en-US"],
+        blocked_by={"id": "4486", "platform": OSPlatform.ALL},
+
     )
     def run(self, firefox):
         about_preferences_home_url_pattern = Pattern("about_preferences_home_url.png")

--- a/tests/firefox/safe_browsing/websites_using_tls_1_0_properly_handled.py
+++ b/tests/firefox/safe_browsing/websites_using_tls_1_0_properly_handled.py
@@ -12,6 +12,8 @@ class Test(FirefoxTest):
         test_case_id="3950",
         test_suite_id="69",
         locale=["en-US"],
+        blocked_by={"id": "4487", "platform": OSPlatform.ALL},
+
     )
     def run(self, firefox):
         bad_ssl_logo_pattern = Pattern("bad_ssl_logo.png")

--- a/tests/firefox/safe_browsing/websites_using_tls_1_1_properly_handled.py
+++ b/tests/firefox/safe_browsing/websites_using_tls_1_1_properly_handled.py
@@ -12,6 +12,8 @@ class Test(FirefoxTest):
         test_case_id="3951",
         test_suite_id="69",
         locale=["en-US"],
+        blocked_by={"id": "4488", "platform": OSPlatform.ALL},
+
     )
     def run(self, firefox):
         bad_ssl_logo_pattern = Pattern("bad_ssl_logo.png")

--- a/tests/firefox/search_and_update/one_click_search_engines_list_can_be_reordered.py
+++ b/tests/firefox/search_and_update/one_click_search_engines_list_can_be_reordered.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="4277",
         test_suite_id="83",
+        blocked_by={"id": "4489", "platform": OSPlatform.ALL},
     )
     def run(self, firefox):
         change_search_settings_pattern = Pattern("change_search_settings.png").similar(0.6)

--- a/tests/firefox/search_and_update/search_code_yandex.py
+++ b/tests/firefox/search_and_update/search_code_yandex.py
@@ -35,6 +35,7 @@ class Test(FirefoxTest):
         test_suite_id="83",
         profile=Profiles.BRAND_NEW,
         preferences={"browser.search.region": fx_region_code, "browser.search.cohort": "jan18-1"},
+        blocked_by={"id": "4490", "platform": OSPlatform.ALL},
     )
     def run(self, firefox):
         url = LocalWeb.FOCUS_TEST_SITE

--- a/tests/firefox/search_and_update/search_code_yandex.py
+++ b/tests/firefox/search_and_update/search_code_yandex.py
@@ -35,7 +35,6 @@ class Test(FirefoxTest):
         test_suite_id="83",
         profile=Profiles.BRAND_NEW,
         preferences={"browser.search.region": fx_region_code, "browser.search.cohort": "jan18-1"},
-        blocked_by={"id": "4490", "platform": OSPlatform.ALL},
     )
     def run(self, firefox):
         url = LocalWeb.FOCUS_TEST_SITE

--- a/tests/firefox/session_restore/restore_from_new_window.py
+++ b/tests/firefox/session_restore/restore_from_new_window.py
@@ -14,6 +14,7 @@ class Test(FirefoxTest):
         locales=Locales.ENGLISH,
         profile=Profiles.BRAND_NEW,
         preferences={"browser.warnOnQuit": False, },
+        blocked_by={"id": "4491", "platform": OSPlatform.ALL},
     )
     def run(self, firefox):
         new_tab()


### PR DESCRIPTION
Applying this patch will block 15 test scripts. The following mentioned test scripts failed during the nightly run.

saved_cc_available_in_private_session
delete_cookies_when_closing.py
no_third_party_cookies
private_browsing_autofill
add_links_keyboard_shortcuts
download_paused_unpaused.py
paste_html
paste_html_in_private_window
find_with_dark_background
ff_home_content_highlights_displayed_in_1_or_2_rows.py
ff_select_which_highlights_to_display
websites_using_tls_1_0_properly_handled
websites_using_tls_1_1_properly_handled
one_click_search_engines_list_can_be_reordered
restore_from_new_window.py

Test failure reason can be seen by visiting following issues: 

#4476
#4477
#4478
#4479
#4480
#4386
#4481
#4482
#4485
#4483
#4486
#4487
#4488
#4489
#4491
