### PR TITLE
26 Test scripts blocked from nightly run execution

### DIFF
--- a/tests/firefox/bookmark/edit_bookmark_from_bookmarks_sidebar.py
+++ b/tests/firefox/bookmark/edit_bookmark_from_bookmarks_sidebar.py
@@ -12,7 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="168937",
         test_suite_id="2525",
-        blocked_by={"id": "1527258", "platform": OSPlatform.WINDOWS},
+        blocked_by={"id": "4506", "platform": OSPlatform.ALL},
     )
     def run(self, firefox):
         properties_option_pattern = Pattern("properties_option.png")

--- a/tests/firefox/bookmark/edit_bookmark_from_recently_bookmarked_section.py
+++ b/tests/firefox/bookmark/edit_bookmark_from_recently_bookmarked_section.py
@@ -13,7 +13,7 @@ class Test(FirefoxTest):
         test_case_id="165492",
         test_suite_id="2525",
         profile=Profiles.TEN_BOOKMARKS,
-        blocked_by={"id": "1527258", "platform": OSPlatform.WINDOWS},
+        blocked_by={"id": "4507", "platform": OSPlatform.ALL},
     )
     def run(self, firefox):
         properties_option_pattern = Pattern("properties_option.png")

--- a/tests/firefox/bookmark/open_all_bookmarks_from_most_visited_section.py
+++ b/tests/firefox/bookmark/open_all_bookmarks_from_most_visited_section.py
@@ -13,6 +13,7 @@ class Test(FirefoxTest):
         test_case_id="163381",
         test_suite_id="2525",
         profile=Profiles.TEN_BOOKMARKS,
+        blocked_by={"id": "4525", "platform": OSPlatform.LINUX},
     )
     def run(self, firefox):
         firefox_menu_bookmarks_pattern = Pattern("bookmarks_top_menu.png")

--- a/tests/firefox/bookmark/remove_tags_from_a_bookmark.py
+++ b/tests/firefox/bookmark/remove_tags_from_a_bookmark.py
@@ -13,6 +13,7 @@ class Test(FirefoxTest):
         test_case_id="4150",
         test_suite_id="2525",
         profile=Profiles.TEN_BOOKMARKS,
+        blocked_by={"id": "4509", "platform": OSPlatform.ALL},
     )
     def run(self, firefox):
         moz_bookmark_pattern = Pattern("moz_sidebar_bookmark.png").similar(0.95)

--- a/tests/firefox/find_toolbar/open_find_toolbar.py
+++ b/tests/firefox/find_toolbar/open_find_toolbar.py
@@ -7,7 +7,13 @@ from targets.firefox.fx_testcase import *
 
 
 class Test(FirefoxTest):
-    @pytest.mark.details(description="Open find toolbar", locale=["en-US"], test_case_id="127238", test_suite_id="2085")
+    @pytest.mark.details(
+        description="Open find toolbar",
+        locale=["en-US"],
+        test_case_id="127238",
+        test_suite_id="2085",
+        blocked_by={"id": "4528", "platform": OSPlatform.WINDOWS},
+    )
     def run(self, firefox):
         open_find()
         edit_select_all()

--- a/tests/firefox/in_browser_pdf/image_rich_properly_opened_and_navigated.py
+++ b/tests/firefox/in_browser_pdf/image_rich_properly_opened_and_navigated.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=[Locales.ENGLISH],
         test_case_id="3933",
         test_suite_id="65",
+        blocked_by={"id": "4529", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         zoom_in_button_pattern = Pattern("zoom_in_button.png").similar(0.7)

--- a/tests/firefox/in_browser_pdf/pdf_zoom.py
+++ b/tests/firefox/in_browser_pdf/pdf_zoom.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=[Locales.ENGLISH],
         test_case_id="3928",
         test_suite_id="65",
+        blocked_by={"id": "4530", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         pdf_file_page_contents_zoomed_in_pattern = Pattern("pdf_file_page_contents_zoomed_in.png").similar(0.7)

--- a/tests/firefox/prefs/cookies_site_data_can_be_managed_via_panel.py
+++ b/tests/firefox/prefs/cookies_site_data_can_be_managed_via_panel.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         test_case_id="143633",
         test_suite_id="2241",
         locale=["en-US"],
+        blocked_by={"id": "4498", "platform": [OSPlatform.WINDOWS, OSPlatform.MAC]},
     )
     def run(self, firefox):
         save_changes_button_pattern = AboutPreferences.Privacy.Exceptions.SAVE_CHANGES_BUTTON

--- a/tests/firefox/prefs/default_font_can_be_changed.py
+++ b/tests/firefox/prefs/default_font_can_be_changed.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         test_case_id="143553",
         test_suite_id="2241",
         locale=["en-US"],
+        blocked_by={"id": "4502", "platform": [OSPlatform.WINDOWS, OSPlatform.MAC]},
     )
     def run(self, firefox):
         about_preferences_general_url_pattern = Pattern("about_preferences_general_url.png")

--- a/tests/firefox/prefs/ff_can_be_set_accept_cookies_site_data.py
+++ b/tests/firefox/prefs/ff_can_be_set_accept_cookies_site_data.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         test_case_id="143653",
         test_suite_id="2241",
         locale=["en-US"],
+        blocked_by={"id": "4499", "platform": [OSPlatform.WINDOWS, OSPlatform.MAC]},
     )
     def run(self, firefox):
         save_changes_button_pattern = AboutPreferences.Privacy.Exceptions.SAVE_CHANGES_BUTTON

--- a/tests/firefox/prefs/ff_can_be_set_always_private.py
+++ b/tests/firefox/prefs/ff_can_be_set_always_private.py
@@ -13,6 +13,7 @@ class Test(FirefoxTest):
         test_case_id="143606",
         test_suite_id="2241",
         locale=["en-US"],
+        blocked_by={"id": "4531", "platform": [OSPlatform.WINDOWS, OSPlatform.MAC]},
         preferences={
             "browser.download.dir": PathManager.get_downloads_dir(),
             "browser.download.folderList": 2,

--- a/tests/firefox/prefs/ff_can_be_set_block_cookies_site_data.py
+++ b/tests/firefox/prefs/ff_can_be_set_block_cookies_site_data.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         test_case_id="143655",
         test_suite_id="2241",
         locale=["en-US"],
+        blocked_by={"id": "4500", "platform": [OSPlatform.WINDOWS, OSPlatform.MAC]},
     )
     def run(self, firefox):
         save_changes_button_pattern = AboutPreferences.Privacy.Exceptions.SAVE_CHANGES_BUTTON

--- a/tests/firefox/prefs/ff_can_be_set_keep_cookies_for_session.py
+++ b/tests/firefox/prefs/ff_can_be_set_keep_cookies_for_session.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         test_case_id="143634",
         test_suite_id="2241",
         locale=["en-US"],
+        blocked_by={"id": "4501", "platform": [OSPlatform.WINDOWS, OSPlatform.MAC]},
     )
     def run(self, firefox):
         custom_level_option_pattern = Pattern("custom_level_option.png")

--- a/tests/firefox/prefs/firefox_can_allow_deny_pages_to_choose_own_fonts.py
+++ b/tests/firefox/prefs/firefox_can_allow_deny_pages_to_choose_own_fonts.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         test_case_id="143559",
         test_suite_id="2241",
         locale=["en-US"],
+        blocked_by={"id": "4526", "platform": OSPlatform.LINUX},
     )
     def run(self, firefox):
         preferences_general_option_pattern = Pattern("preferences_general_option.png")

--- a/tests/firefox/prefs/highlights_can_be_enabled_disabled.py
+++ b/tests/firefox/prefs/highlights_can_be_enabled_disabled.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="161669",
         test_suite_id="2241",
+        blocked_by={"id": "4503", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         highlights_options_pattern = Pattern("highlights_option.png")

--- a/tests/firefox/prefs/remove_selected_button_grayed_out_after_site_deselected.py
+++ b/tests/firefox/prefs/remove_selected_button_grayed_out_after_site_deselected.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         test_case_id="145301",
         test_suite_id="2241",
         locale=["en-US"],
+        blocked_by={"id": "4504", "platform": [OSPlatform.WINDOWS, OSPlatform.MAC]},
     )
     def run(self, firefox):
         manage_data_button = Pattern("manage_data_button_highlighted.png")

--- a/tests/firefox/prefs/several_custom_settings_remains_checked.py
+++ b/tests/firefox/prefs/several_custom_settings_remains_checked.py
@@ -13,6 +13,7 @@ class Test(FirefoxTest):
         test_case_id="249028",
         test_suite_id="2241",
         locale=["en-US"],
+        blocked_by={"id": "4505", "platform": [OSPlatform.WINDOWS, OSPlatform.MAC]},
     )
     def run(self, firefox):
         use_custom_settings_for_history_pattern = Pattern("custom_history_settings.png")

--- a/tests/firefox/private_browsing/download_from_private_session.py
+++ b/tests/firefox/private_browsing/download_from_private_session.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locales=["en-US"],
         test_case_id="101676",
         test_suite_id="1826",
+        blocked_by={"id": "4527", "platform": OSPlatform.LINUX},
         preferences={
             "browser.download.dir": PathManager.get_downloads_dir(),
             "browser.download.folderList": 2,

--- a/tests/firefox/private_browsing/track_protection_exceptions_added_not_remembered_private_session.py
+++ b/tests/firefox/private_browsing/track_protection_exceptions_added_not_remembered_private_session.py
@@ -13,6 +13,7 @@ class Test(FirefoxTest):
         test_case_id="107718",
         test_suite_id="1826",
         locale=["en-US"],
+        blocked_by={"id": "4496", "platform": [OSPlatform.WINDOWS, OSPlatform.MAC]},
     )
     def run(self, firefox):
         blocking_turn_off_pattern = Pattern("turn_off_blocking_for_site_button.png")

--- a/tests/firefox/private_browsing/track_protection_exceptions_normal_sessions.py
+++ b/tests/firefox/private_browsing/track_protection_exceptions_normal_sessions.py
@@ -13,6 +13,7 @@ class Test(FirefoxTest):
         test_case_id="107717",
         test_suite_id="1826",
         locales=["en-US"],
+        blocked_by={"id": "4497", "platform": [OSPlatform.WINDOWS, OSPlatform.MAC]},
     )
     def run(self, firefox):
         remove_website_button_pattern = AboutPreferences.Privacy.Exceptions.REMOVE_WEBSITE_BUTTON

--- a/tests/firefox/safe_browsing/safe_browsing_working_in_safe_mode.py
+++ b/tests/firefox/safe_browsing/safe_browsing_working_in_safe_mode.py
@@ -13,6 +13,7 @@ class Test(FirefoxTest):
         test_suite_id="69",
         locale=["en-US"],
         profile=Profiles.BRAND_NEW,
+        blocked_by={"id": "4473", "platform": OSPlatform.MAC},
         preferences={"browser.warnOnQuit": False, "browser.shell.checkDefaultBrowser": False, },
     )
     def run(self, firefox):

--- a/tests/firefox/search_and_update/history_of_previous_searches_is_kept.py
+++ b/tests/firefox/search_and_update/history_of_previous_searches_is_kept.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="4270",
         test_suite_id="83",
+        blocked_by={"id": "4508", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         google_logo_content_search_field_pattern = Pattern("google_logo_content_search_field.png")

--- a/tests/firefox/search_and_update/search_bar_options_work_properly.py
+++ b/tests/firefox/search_and_update/search_bar_options_work_properly.py
@@ -12,6 +12,8 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="4271",
         test_suite_id="83",
+        blocked_by={"id": "4510", "platform": OSPlatform.WINDOWS},
+
     )
     def run(self, firefox):
         google_search_no_input_pattern = Pattern("google_search_no_input.png")

--- a/tests/firefox/toolbars_window_controls/browser_controls_upper_corner.py
+++ b/tests/firefox/toolbars_window_controls/browser_controls_upper_corner.py
@@ -8,7 +8,11 @@ from targets.firefox.fx_testcase import *
 
 class Test(FirefoxTest):
     @pytest.mark.details(
-        description="Browser controls work as expected.", locale=["en-US"], test_case_id="119481", test_suite_id="1998"
+        description="Browser controls work as expected.",
+        locale=["en-US"],
+        test_case_id="119481",
+        test_suite_id="1998",
+        blocked_by={"id": "4511", "platform": [OSPlatform.WINDOWS, OSPlatform.MAC]},
     )
     def run(self, firefox):
         window_controls_minimize_pattern = Pattern("window_controls_minimize.png")

--- a/tests/firefox/toolbars_window_controls/drag_space.py
+++ b/tests/firefox/toolbars_window_controls/drag_space.py
@@ -13,6 +13,7 @@ class Test(FirefoxTest):
         test_case_id="118184",
         test_suite_id="1998",
         exclude=OSPlatform.LINUX,
+        blocked_by={"id": "4512", "platform": [OSPlatform.WINDOWS, OSPlatform.MAC]},
     )
     def run(self, firefox):
         customize_page_drag_space_disabled_pattern = Pattern("customize_page_drag_space_disabled.png")

--- a/tests/firefox/toolbars_window_controls/title_bar_activation.py
+++ b/tests/firefox/toolbars_window_controls/title_bar_activation.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="118183",
         test_suite_id="1998",
+        blocked_by={"id": "4513", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         navigate("about:home")


### PR DESCRIPTION
Applying this patch will block 26 test scripts. The following mentioned test scripts failed during the nightly run.

edit_bookmark_from_bookmarks_sidebar
edit_bookmark_from_recently_bookmarked_section.py
open_all_bookmarks_from_most_visited_section
remove_tags_from_a_bookmark.py
open_find_toolbar
image_rich_properly_opened_and_navigated
pdf_zoom
cookies_site_data_can_be_managed_via_panel.py
default_font_can_be_changed.py
ff_can_be_set_accept_cookies_site_data
ff_can_be_set_always_private
ff_can_be_set_block_cookies_site_data
ff_can_be_set_keep_cookies_for_session
firefox_can_allow_deny_pages_to_choose_own_fonts
highlights_can_be_enabled_disabled
remove_selected_button_grayed_out_after_site_deselected.py
several_custom_settings_remains_checked
download_from_private_session
track_protection_exceptions_added_not_remembered_private_session.py
track_protection_exceptions_normal_sessions.py
history_of_previous_searches_is_kept
search_bar_options_work_properly
browser_controls_upper_corner
drag_space
title_bar_activation
safe_browsing_working_in_safe_mode.py

Test failure reason can be seen by visiting following issues:
#4506
#4507
#4525
#4509
#4528
#4529
#4530
#4498
#4502
#4499
#4531
#4500
#4501
#4526
#4503
#4504
#4505
#4527
#4496
#4497
#4508
#4510
#4511
#4512
#4513
#4473