### PR TITLE
48 Test scripts blocked from nightly run execution

### DIFF
--- a/tests/firefox/awesomebar/search_using_one_offs_while_maximizing_or_minimizing_window.py
+++ b/tests/firefox/awesomebar/search_using_one_offs_while_maximizing_or_minimizing_window.py
@@ -14,6 +14,7 @@ class Test(FirefoxTest):
         test_case_id="108252",
         test_suite_id="1902",
         preferences={"browser.contentblocking.enabled": False},
+        blocked_by={"id": "4547", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         url = LocalWeb.FIREFOX_TEST_SITE

--- a/tests/firefox/bookmark/bookmark_drag_drop_in_library.py
+++ b/tests/firefox/bookmark/bookmark_drag_drop_in_library.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="169274",
         test_suite_id="2525",
+        blocked_by={"id": "4549", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         soap_wiki_tab_pattern = Pattern("soap_wiki_tab.png")

--- a/tests/firefox/bookmark/bookmark_from_most_visited_section_can_be_canceled.py
+++ b/tests/firefox/bookmark/bookmark_from_most_visited_section_can_be_canceled.py
@@ -14,7 +14,7 @@ class Test(FirefoxTest):
         test_case_id="163397",
         test_suite_id="2525",
         profile=Profiles.TEN_BOOKMARKS,
-        exclude=OSPlatform.MAC,
+        blocked_by={"id": "4565", "platform": [OSPlatform.WINDOWS, OSPlatform.MAC]},
     )
     def run(self, firefox):
         firefox_menu_bookmarks_pattern = Pattern("bookmarks_top_menu.png")

--- a/tests/firefox/bookmark/edit_bookmark_from_recently_bookmarked_section.py
+++ b/tests/firefox/bookmark/edit_bookmark_from_recently_bookmarked_section.py
@@ -13,7 +13,7 @@ class Test(FirefoxTest):
         test_case_id="165492",
         test_suite_id="2525",
         profile=Profiles.TEN_BOOKMARKS,
-        blocked_by={"id": "4507", "platform": OSPlatform.ALL},
+        blocked_by={"id": "4478", "platform": [OSPlatform.MAC, OSPlatform.LINUX]},
     )
     def run(self, firefox):
         properties_option_pattern = Pattern("properties_option.png")

--- a/tests/firefox/bookmark/new_bookmark_dialog_window_save_keyword.py
+++ b/tests/firefox/bookmark/new_bookmark_dialog_window_save_keyword.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="171599",
         test_suite_id="2525",
+        blocked_by={"id": "4577", "platform": OSPlatform.MAC},
     )
     def run(self, firefox):
         soap_bookmark_pattern = Pattern("soap_bookmark.png").similar(0.6)

--- a/tests/firefox/bookmark/paste_bookmark_in_library.py
+++ b/tests/firefox/bookmark/paste_bookmark_in_library.py
@@ -8,7 +8,11 @@ from targets.firefox.fx_testcase import *
 
 class Test(FirefoxTest):
     @pytest.mark.details(
-        description="Paste a bookmark in Library", locale=["en-US"], test_case_id="169266", test_suite_id="2525"
+        description="Paste a bookmark in Library",
+        locale=["en-US"],
+        test_case_id="169266",
+        test_suite_id="2525",
+        blocked_by={"id": "4550", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         soap_wiki_tab_pattern = Pattern("soap_wiki_tab.png")

--- a/tests/firefox/download_manager/download_cancel_retry.py
+++ b/tests/firefox/download_manager/download_cancel_retry.py
@@ -14,6 +14,7 @@ class Test(FirefoxTest):
         test_case_id="99470",
         test_suite_id="1827",
         profile=Profiles.BRAND_NEW,
+        blocked_by={"id": "4516", "platform": OSPlatform.LINUX},
         preferences={
             "browser.download.autohideButton": False,
             "browser.download.dir": PathManager.get_downloads_dir(),

--- a/tests/firefox/download_manager/download_warnings_customized_or_disabled_from_the_ui.py
+++ b/tests/firefox/download_manager/download_warnings_customized_or_disabled_from_the_ui.py
@@ -18,6 +18,7 @@ class Test(FirefoxTest):
         test_case_id="99477",
         test_suite_id="1827",
         profile=Profiles.BRAND_NEW,
+        blocked_by={"id": "4542", "platform": OSPlatform.ALL},
         preferences={
             "browser.download.dir": PathManager.get_downloads_dir(),
             "browser.download.folderList": 2,

--- a/tests/firefox/download_manager/downloads_button_works_properly_positioned_in_the_tabs_bar.py
+++ b/tests/firefox/download_manager/downloads_button_works_properly_positioned_in_the_tabs_bar.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         test_case_id="99473",
         test_suite_id="1827",
         profile=Profiles.BRAND_NEW,
+        blocked_by={"id": "4546", "platform": [OSPlatform.WINDOWS, OSPlatform.LINUX]},
         preferences={
             "browser.download.dir": PathManager.get_downloads_dir(),
             "browser.download.folderList": 2,

--- a/tests/firefox/download_manager/malicious_warning.py
+++ b/tests/firefox/download_manager/malicious_warning.py
@@ -15,6 +15,7 @@ class Test(FirefoxTest):
         test_case_id="99498",
         test_suite_id="1827",
         profile=Profiles.BRAND_NEW,
+        blocked_by={"id": "4543", "platform": OSPlatform.ALL},
         preferences={
             "browser.download.dir": PathManager.get_downloads_dir(),
             "browser.download.folderList": 2,

--- a/tests/firefox/drag_and_drop/drop_jpeg_image.py
+++ b/tests/firefox/drag_and_drop/drop_jpeg_image.py
@@ -39,6 +39,7 @@ class Test(FirefoxTest):
         test_case_id="165084",
         test_suite_id="5259",
         set_profile_pref={"devtools.chrome.enabled": True},
+        blocked_by={"id": "4567", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         library_import_backup_pattern = Library.IMPORT_AND_BACKUP_BUTTON

--- a/tests/firefox/drag_and_drop/drop_jpeg_image_in_private_window.py
+++ b/tests/firefox/drag_and_drop/drop_jpeg_image_in_private_window.py
@@ -39,6 +39,7 @@ class Test(FirefoxTest):
         test_case_id="165085",
         test_suite_id="5259",
         set_profile_pref={"devtools.chrome.enabled": True},
+        blocked_by={"id": "4563", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         library_import_backup_pattern = Library.IMPORT_AND_BACKUP_BUTTON

--- a/tests/firefox/drag_and_drop/drop_pdf_file.py
+++ b/tests/firefox/drag_and_drop/drop_pdf_file.py
@@ -39,6 +39,7 @@ class Test(FirefoxTest):
         test_case_id="165080",
         test_suite_id="5259",
         set_profile_pref={"devtools.chrome.enabled": True},
+        blocked_by={"id": "4564", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         library_import_backup_pattern = Library.IMPORT_AND_BACKUP_BUTTON

--- a/tests/firefox/drag_and_drop/drop_pdf_file_in_private_window.py
+++ b/tests/firefox/drag_and_drop/drop_pdf_file_in_private_window.py
@@ -34,7 +34,11 @@ class Test(FirefoxTest):
         copy_file(original_txtfile_path, backup_txtfile_path)
 
     @pytest.mark.details(
-        description="Drop .pdf File in demopage", locale=["en-US"], test_case_id="165080", test_suite_id="5259"
+        description="Drop .pdf File in demopage",
+        locale=["en-US"],
+        test_case_id="165080",
+        test_suite_id="5259",
+        blocked_by={"id": "4553", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         library_import_backup_pattern = Library.IMPORT_AND_BACKUP_BUTTON

--- a/tests/firefox/drag_and_drop/drop_png_image.py
+++ b/tests/firefox/drag_and_drop/drop_png_image.py
@@ -38,6 +38,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="165089",
         test_suite_id="5259",
+        blocked_by={"id": "4554", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         library_import_backup_pattern = Library.IMPORT_AND_BACKUP_BUTTON

--- a/tests/firefox/drag_and_drop/drop_png_image_in_private_window.py
+++ b/tests/firefox/drag_and_drop/drop_png_image_in_private_window.py
@@ -38,6 +38,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="165086",
         test_suite_id="5259",
+        blocked_by={"id": "4566", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         library_import_backup_pattern = Library.IMPORT_AND_BACKUP_BUTTON

--- a/tests/firefox/drag_and_drop/drop_txt_file.py
+++ b/tests/firefox/drag_and_drop/drop_txt_file.py
@@ -33,7 +33,11 @@ class Test(FirefoxTest):
         copy_file(original_txtfile_path, backup_txtfile_path)
 
     @pytest.mark.details(
-        description="Drop .txt File in demopage", locale=["en-US"], test_case_id="165086", test_suite_id="5259"
+        description="Drop .txt File in demopage",
+        locale=["en-US"],
+        test_case_id="165086",
+        test_suite_id="5259",
+        blocked_by={"id": "4558", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         library_import_backup_pattern = Library.IMPORT_AND_BACKUP_BUTTON

--- a/tests/firefox/drag_and_drop/drop_txt_file_in_private_window.py
+++ b/tests/firefox/drag_and_drop/drop_txt_file_in_private_window.py
@@ -37,6 +37,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="165086",
         test_suite_id="5259",
+        blocked_by={"id": "4561", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         library_import_backup_pattern = Library.IMPORT_AND_BACKUP_BUTTON

--- a/tests/firefox/find_toolbar/find_search_vertical_text.py
+++ b/tests/firefox/find_toolbar/find_search_vertical_text.py
@@ -13,6 +13,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="127278",
         test_suite_id="2085",
+        blocked_by={"id": "4570", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         word_mozilla_first_selected_pattern = Pattern("word_mozilla_first_selected.png")

--- a/tests/firefox/history/clear_all_history.py
+++ b/tests/firefox/history/clear_all_history.py
@@ -8,7 +8,8 @@ from targets.firefox.fx_testcase import *
 
 class Test(FirefoxTest):
     @pytest.mark.details(
-        description="Clear all the History.", locale=["en-US"], test_case_id="172045", test_suite_id="2000"
+        description="Clear all the History.", locale=["en-US"], test_case_id="172045", test_suite_id="2000",
+        blocked_by={"id": "4323", "platform": OSPlatform.MAC},
     )
     def run(self, firefox):
         searched_history_logo_pattern = Sidebar.HistorySidebar.EXPLORED_HISTORY_ICON.similar(0.9)

--- a/tests/firefox/history/delete_history_from_library_context_menu.py
+++ b/tests/firefox/history/delete_history_from_library_context_menu.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="178346",
         test_suite_id="2000",
+        blocked_by={"id": "4578", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         mozilla_bookmark_focus_pattern = Pattern("mozilla_bookmark_focus.png")

--- a/tests/firefox/history/history_sidebar_copy_site_to_url_bar.py
+++ b/tests/firefox/history/history_sidebar_copy_site_to_url_bar.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="120129",
         test_suite_id="2000",
+        blocked_by={"id": "4578", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         search_history_box_pattern = Sidebar.HistorySidebar.SEARCH_BOX

--- a/tests/firefox/history/history_sidebar_delete_site.py
+++ b/tests/firefox/history/history_sidebar_delete_site.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="120130",
         test_suite_id="2000",
+        blocked_by={"id": "4578", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         search_history_box_pattern = Sidebar.HistorySidebar.SEARCH_BOX

--- a/tests/firefox/history/history_sidebar_delete_site_verify_if_remembered.py
+++ b/tests/firefox/history/history_sidebar_delete_site_verify_if_remembered.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="120131",
         test_suite_id="2000",
+        blocked_by={"id": "4578", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         search_history_box_pattern = Sidebar.HistorySidebar.SEARCH_BOX

--- a/tests/firefox/prefs/ff_can_be_set_always_private.py
+++ b/tests/firefox/prefs/ff_can_be_set_always_private.py
@@ -19,6 +19,7 @@ class Test(FirefoxTest):
             "browser.download.folderList": 2,
             "browser.download.useDownloadDir": True,
         },
+        blocked_by={"id": "4531", "platform": OSPlatform.MAC},
     )
     def run(self, firefox):
         always_private_pattern = Pattern("always_private.png")

--- a/tests/firefox/prefs/ff_can_be_set_clear_data_on_exit.py
+++ b/tests/firefox/prefs/ff_can_be_set_clear_data_on_exit.py
@@ -18,6 +18,7 @@ class Test(FirefoxTest):
             "browser.download.folderList": 2,
             "browser.download.useDownloadDir": True,
         },
+        blocked_by={"id": "4535", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         always_private_pattern = Pattern("always_private.png")

--- a/tests/firefox/prefs/ff_can_be_set_never_remember_history.py
+++ b/tests/firefox/prefs/ff_can_be_set_never_remember_history.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="143604",
         test_suite_id="2241",
+        blocked_by={"id": "4536", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         remember_history_selected_pattern = Pattern("remember_history_selected.png")

--- a/tests/firefox/prefs/history_can_be_cleared_via_history_panel.py
+++ b/tests/firefox/prefs/history_can_be_cleared_via_history_panel.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         test_case_id="143611",
         test_suite_id="2241",
         locale=["en-US"],
+        blocked_by={"id": "4552", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         clear_everything_history_pattern = Pattern("clear_everything_history.png")

--- a/tests/firefox/prefs/links_open_in_tabs.py
+++ b/tests/firefox/prefs/links_open_in_tabs.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         test_case_id="143550",
         test_suite_id="2241",
         locale=["en-US"],
+        blocked_by={"id": "4537", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         navigate_load_listener_page_title_pattern = Pattern("navigate_page_title.png").similar(0.6)

--- a/tests/firefox/prefs/recommended_by_pocket.py
+++ b/tests/firefox/prefs/recommended_by_pocket.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="161668",
         test_suite_id="2241",
+        blocked_by={"id": "4560", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         recommended_by_pocket_option = Pattern("recommended_by_pocket_option.png")

--- a/tests/firefox/prefs/switch_immediately_opened_link.py
+++ b/tests/firefox/prefs/switch_immediately_opened_link.py
@@ -13,6 +13,7 @@ class Test(FirefoxTest):
         test_suite_id="2241",
         locale=["en-US"],
         preferences={"browser.tabs.loadinBackground": False},
+        blocked_by={"id": "4573", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         when_you_open_link_checked_pattern = Pattern("when_you_open_link_checked.png")

--- a/tests/firefox/prefs/top_sites_can_be_displayed_in_1_or_4_rows.py
+++ b/tests/firefox/prefs/top_sites_can_be_displayed_in_1_or_4_rows.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         test_suite_id="2241",
         locale=["en-US"],
         preferences={"devtools.chrome.enabled": True},
+        blocked_by={"id": "4467", "platform": [OSPlatform.LINUX, OSPlatform.MAC]},
     )
     def run(self, firefox):
         top_sites_drop_down_1_row_pattern = Pattern("home_top_sites_most_visit_default_value.png")

--- a/tests/firefox/private_browsing/private_session_lost.py
+++ b/tests/firefox/private_browsing/private_session_lost.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         test_case_id="107721",
         test_suite_id="1826",
         locales=["en-US"],
+        blocked_by={"id": "4571", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         private_window_inactive_pattern = Pattern("private_window_inactive.png")

--- a/tests/firefox/safe_browsing/safe_browsing_working_in_safe_mode.py
+++ b/tests/firefox/safe_browsing/safe_browsing_working_in_safe_mode.py
@@ -15,6 +15,7 @@ class Test(FirefoxTest):
         profile=Profiles.BRAND_NEW,
         blocked_by={"id": "4473", "platform": OSPlatform.MAC},
         preferences={"browser.warnOnQuit": False, "browser.shell.checkDefaultBrowser": False, },
+        blocked_by={"id": "4538", "platform": [OSPlatform.WINDOWS, OSPlatform.MAC]},
     )
     def run(self, firefox):
         start_in_safe_mode_button_pattern = Pattern("start_in_safe_mode_button.png")

--- a/tests/firefox/search_and_update/search_code_google.py
+++ b/tests/firefox/search_and_update/search_code_google.py
@@ -39,6 +39,7 @@ class Test(FirefoxTest):
         test_suite_id="83",
         profile=Profiles.BRAND_NEW,
         preferences={"browser.search.region": fx_region_code, "browser.search.cohort": "nov17-1"},
+        blocked_by={"id": "4539", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         url = LocalWeb.FOCUS_TEST_SITE

--- a/tests/firefox/search_and_update/search_code_yandex.py
+++ b/tests/firefox/search_and_update/search_code_yandex.py
@@ -35,6 +35,7 @@ class Test(FirefoxTest):
         test_suite_id="83",
         profile=Profiles.BRAND_NEW,
         preferences={"browser.search.region": fx_region_code, "browser.search.cohort": "jan18-1"},
+        blocked_by={"id": "4490", "platform": OSPlatform.ALL},
     )
     def run(self, firefox):
         url = LocalWeb.FOCUS_TEST_SITE

--- a/tests/firefox/session_restore/restore_previous_session_option_is_not_available_in_private_window.py
+++ b/tests/firefox/session_restore/restore_previous_session_option_is_not_available_in_private_window.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         test_case_id="115426",
         test_suite_id="68",
         locales=Locales.ENGLISH,
+        blocked_by={"id": "4540", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         restore_previous_session_pattern = Pattern("restore_previous_session_item.png")

--- a/tests/firefox/session_restore/restored_for_dirty_profile.py
+++ b/tests/firefox/session_restore/restored_for_dirty_profile.py
@@ -14,6 +14,7 @@ class Test(FirefoxTest):
         locales=Locales.ENGLISH,
         set_profile_pref={"browser.startup.homepage": "about:home"},
         profile=Profiles.TEN_BOOKMARKS,
+        blocked_by={"id": "4320", "platform": OSPlatform.ALL},
     )
     def run(self, firefox):
         default_zoom_level_toolbar_customize_page_pattern = (NavBar.DEFAULT_ZOOM_LEVEL_TOOLBAR_CUSTOMIZE_PAGE).similar(

--- a/tests/firefox/toolbars_window_controls/browser_control_console.py
+++ b/tests/firefox/toolbars_window_controls/browser_control_console.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="120464",
         test_suite_id="1998",
+        blocked_by={"id": "4548", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         browser_console = Pattern("browser_console.png")

--- a/tests/firefox/toolbars_window_controls/download_dialog_controls.py
+++ b/tests/firefox/toolbars_window_controls/download_dialog_controls.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="118801",
         test_suite_id="1998",
+        blocked_by={"id": "4319", "platform": OSPlatform.ALL},
     )
     def run(self, firefox):
         test_pdf_pattern = Pattern("moz_fast.png")

--- a/tests/firefox/toolbars_window_controls/library_controls.py
+++ b/tests/firefox/toolbars_window_controls/library_controls.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="120467",
         test_suite_id="1998",
+        blocked_by={"id": "4555", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         library_title_pattern = Library.TITLE

--- a/tests/firefox/toolbars_window_controls/print_dialog_controls.py
+++ b/tests/firefox/toolbars_window_controls/print_dialog_controls.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="118804",
         test_suite_id="1998",
+        blocked_by={"id": "4541", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         test_pdf_pattern = Pattern("moz_fast.png")

--- a/tests/firefox/zoom_indicator/location_bar_zoom_indicator_animation.py
+++ b/tests/firefox/zoom_indicator/location_bar_zoom_indicator_animation.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US", "zh-CN", "es-ES", "de", "fr", "ru", "ko", "pt-PT", "vi", "pl", "tr", "ro", "ja"],
         test_case_id="7451",
         test_suite_id="242",
+        blocked_by={"id": "4557 ", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         url = LocalWeb.FIREFOX_TEST_SITE

--- a/tests/firefox/zoom_indicator/location_bar_zoom_indicator_animation_mouse_wheel.py
+++ b/tests/firefox/zoom_indicator/location_bar_zoom_indicator_animation_mouse_wheel.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US", "zh-CN", "es-ES", "de", "fr", "ru", "ko", "pt-PT", "vi", "pl", "tr", "ro", "ja"],
         test_case_id="7446",
         test_suite_id="242",
+        blocked_by={"id": "4559", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         url = LocalWeb.FIREFOX_TEST_SITE

--- a/tests/firefox/zoom_indicator/zoom_controls_on_toolbar.py
+++ b/tests/firefox/zoom_indicator/zoom_controls_on_toolbar.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="7443",
         test_suite_id="242",
+        blocked_by={"id": "4568", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         url = LocalWeb.FIREFOX_TEST_SITE

--- a/tests/firefox/zoom_indicator/zoom_in_hamburger_menu.py
+++ b/tests/firefox/zoom_indicator/zoom_in_hamburger_menu.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="7458",
         test_suite_id="242",
+        blocked_by={"id": "4551", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         url1 = "about:home"

--- a/tests/firefox/zoom_indicator/zoom_level_window_state.py
+++ b/tests/firefox/zoom_indicator/zoom_level_window_state.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="7449",
         test_suite_id="242",
+        blocked_by={"id": "4562", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         url = LocalWeb.FIREFOX_TEST_SITE

--- a/tests/firefox/zoom_indicator/zoom_level_window_state_mouse_wheel.py
+++ b/tests/firefox/zoom_indicator/zoom_level_window_state_mouse_wheel.py
@@ -12,6 +12,7 @@ class Test(FirefoxTest):
         locale=["en-US"],
         test_case_id="7454",
         test_suite_id="242",
+        blocked_by={"id": "4556", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         url = LocalWeb.FIREFOX_TEST_SITE


### PR DESCRIPTION
Applying this patch will block 48 test scripts. The following mentioned test scripts failed during nightly run:

search_using_one_offs_while_maximizing_or_minimizing_window
bookmark_drag_drop_in_library
paste_bookmark_in_library
bookmark_from_most_visited_section_can_be_canceled
clear_preview_panel_while_downloading
remove_tags_from_a_bookmark
download_hover_behavior
download_summary
downloads_private_window_not_leak_non_private_window
notifications_are_displayed_for_finished_or_new_downloads
number_of_downloads_properly_truncated
show_all_downloads_states
user_is_prompted_when_trying_to_close_the_browser_while_downloading
user_is_prompted_when_trying_to_close_the_private_window_while_downloading
edit_bookmark_from_recently_bookmarked_section
new_bookmark_dialog_window_save_keyword
download_warnings_customized_or_disabled_from_the_ui
malicious_warning
download_cancel_retry
downloads_button_works_properly_positioned_in_the_tabs_bar
drop_pdf_file_in_private_window
drop_png_image
drop_txt_file
drop_txt_file_in_private_window
drop_jpeg_image_in_private_window
drop_pdf_file
drop_png_image_in_private_window
drop_jpeg_image
find_search_vertical_text
delete_history_from_library_context_menu
history_sidebar_delete_site
history_sidebar_delete_site_verify_if_remembered
history_sidebar_copy_site_to_url_bar
clear_all_history
ff_can_be_set_clear_data_on_exit
top_sites_can_be_displayed_in_1_or_4_rows
history_can_be_cleared_via_history_panel
recommended_by_pocket
ff_can_be_set_never_remember_history
links_open_in_tabs
switch_immediately_opened_link
ff_can_be_set_always_private
private_session_lost
safe_browsing_working_in_safe_mode
search_code_yandex
search_code_google
restore_previous_session_option_is_not_available_in_private_window
restored_for_dirty_profile
print_dialog_controls
download_dialog_controls
browser_control_console
library_controls
zoom_in_hamburger_menu
zoom_level_window_state_mouse_wheel
location_bar_zoom_indicator_animation
location_bar_zoom_indicator_animation_mouse_wheel
zoom_level_window_state
zoom_controls_on_toolbar


Test failure reason can be seen by visiting following issues: 
#4547
#4549
#4550
#4565
#4515
#4509
#4517
#4518
#4519
#4520
#4521
#4522
#4523
#4524
#4507
#4577
#4542
#4543
#4516
#4546
#4553
#4554
#4558
#4561
#4563
#4564
#4566
#4567
#4570
#4578
#4578
#4578
#4578
#4323
#4535
#4467
#4552
#4560
#4536
#4537
#4573
#4531
#4571
#4538
#4490
#4539
#4540
#4541
#4320
#4319
#4548
#4555
#4551
#4556
#4557
#4559
#4562
#4568