### PR TITLE
Fix: Double blocked_by statement in test script

### DIFF
--- a/tests/firefox/bookmark/bookmark_from_most_visited_section_can_be_canceled.py
+++ b/tests/firefox/bookmark/bookmark_from_most_visited_section_can_be_canceled.py
@@ -14,7 +14,8 @@ class Test(FirefoxTest):
         test_case_id="163397",
         test_suite_id="2525",
         profile=Profiles.TEN_BOOKMARKS,
-        blocked_by={"id": "4565", "platform": [OSPlatform.WINDOWS, OSPlatform.MAC]},
+        exclude=OSPlatform.MAC,
+        blocked_by={"id": "4565", "platform": OSPlatform.WINDOWS},
     )
     def run(self, firefox):
         firefox_menu_bookmarks_pattern = Pattern("bookmarks_top_menu.png")

--- a/tests/firefox/prefs/ff_can_be_set_always_private.py
+++ b/tests/firefox/prefs/ff_can_be_set_always_private.py
@@ -19,7 +19,6 @@ class Test(FirefoxTest):
             "browser.download.folderList": 2,
             "browser.download.useDownloadDir": True,
         },
-        blocked_by={"id": "4531", "platform": OSPlatform.MAC},
     )
     def run(self, firefox):
         always_private_pattern = Pattern("always_private.png")

--- a/tests/firefox/safe_browsing/safe_browsing_working_in_safe_mode.py
+++ b/tests/firefox/safe_browsing/safe_browsing_working_in_safe_mode.py
@@ -13,9 +13,8 @@ class Test(FirefoxTest):
         test_suite_id="69",
         locale=["en-US"],
         profile=Profiles.BRAND_NEW,
-        blocked_by={"id": "4473", "platform": OSPlatform.MAC},
         preferences={"browser.warnOnQuit": False, "browser.shell.checkDefaultBrowser": False, },
-        blocked_by={"id": "4538", "platform": [OSPlatform.WINDOWS, OSPlatform.MAC]},
+        blocked_by={"id": "4473_4538", "platform": [OSPlatform.WINDOWS, OSPlatform.MAC]},
     )
     def run(self, firefox):
         start_in_safe_mode_button_pattern = Pattern("start_in_safe_mode_button.png")


### PR DESCRIPTION
Removed double blocked_by statement from following test cases: 
safe_browsing_working_in_safe_mode.py
ff_can_be_set_always_private.py

Added "exclude=OSPlatform.MAC" in bookmark_from_most_visited_section_can_be_canceled.py